### PR TITLE
Loosen APCu check for SourceCache

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -150,10 +150,8 @@ class ContainerBuilder
         // Mutable definition source
         $source->setMutableDefinitionSource(new DefinitionArray([], $autowiring));
 
-        if ($this->sourceCache) {
-            if (!SourceCache::isSupported()) {
-                throw new \Exception('APCu is not enabled, PHP-DI cannot use it as a cache');
-            }
+        // use cache if isSupported check passes, otherwise proceed without cache and do not throw an exception
+        if ($this->sourceCache && SourceCache::isSupported()) {
             // Wrap the source with the cache decorator
             $source = new SourceCache($source);
         }


### PR DESCRIPTION
Use sourceCache if isSupported check passes, otherwise proceed without cache and do not throw an exception

- so that php-di does not break if there is any problem with apcu - instead of having to wrap ContainerBuilder::build() with try...catch block