### PR TITLE
[php-di v7] Optimize compiled factory definitions

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,9 +15,14 @@ return $config->setRules([
     '@Symfony' => true,
     '@Symfony:risky' => true,
     'array_syntax' => ['syntax' => 'short'],
-    'braces' => [
-        'allow_single_line_closure' => true,
-    ],
+    'single_space_around_construct' => true,
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => true,
+    'declare_parentheses' => true,
+    'no_multiple_statements_per_line' => true,
+    'braces_position' => true,
+    'statement_indentation' => true,
+    'no_extra_blank_lines' => true,
     'concat_space' => [
         'spacing' => 'one',
     ],


### PR DESCRIPTION
**Version compatible with PHP `^8.0` as a successor of https://github.com/ovos/PHP-DI/pull/6**

#### Details (copied from #6)

- compile final function with injected dependencies
- only for closure factories for now (as the first step)

1) Simple example:
before:
```php
return $this->resolveFactory(static function () {
    return 'bar';
}, 'factory');
```
now:
```php
return (static function () {
    return 'bar';
})();
```
2) More complex example:
before:
```php
return $this->resolveFactory(static function (\DI\Factory\RequestedEntry $entry, \DI\Container $c, $dbName = null) {
    $parts = explode('.', $entry->getName());
    $type = $parts[1];
    if ($dbName === null && isset($parts[2])) {
        $dbName = $parts[2] !== '0' ? $parts[2] : false;
    }
    $factory = $c->get(\CMS\Database\ConnectionFactory::class);
    return $factory->create($type, $dbName);
}, 'db.mysql', [
            'dbName' => NULL,
        ]);
```
now:
```php
return (static function (\DI\Factory\RequestedEntry $entry, \DI\Container $c, $dbName = null) {
    $parts = explode('.', $entry->getName());
    $type = $parts[1];
    if ($dbName === null && isset($parts[2])) {
        $dbName = $parts[2] !== '0' ? $parts[2] : false;
    }
    $factory = $c->get(\CMS\Database\ConnectionFactory::class);
    return $factory->create($type, $dbName);
})(new DI\Compiler\RequestedEntryHolder('db.mysql'), $this->get5cc4bd5c6dc8e808068072(), NULL);
```