### PR TITLE
[php-di v7] Loosen APCu check for SourceCache

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,9 +15,14 @@ return $config->setRules([
     '@Symfony' => true,
     '@Symfony:risky' => true,
     'array_syntax' => ['syntax' => 'short'],
-    'braces' => [
-        'allow_single_line_closure' => true,
-    ],
+    'single_space_around_construct' => true,
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => true,
+    'declare_parentheses' => true,
+    'no_multiple_statements_per_line' => true,
+    'braces_position' => true,
+    'statement_indentation' => true,
+    'no_extra_blank_lines' => true,
     'concat_space' => [
         'spacing' => 'one',
     ],


### PR DESCRIPTION
Version compatible with PHP `^8.0` as a successor of #3 

#### Details (copied from #3)

Use sourceCache if isSupported check passes, otherwise proceed without cache and do not throw an exception

- so that php-di does not break if there is any problem with apcu - instead of having to wrap ContainerBuilder::build() with try...catch block